### PR TITLE
refactor: use HOME variable in zsh config

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -9,7 +9,7 @@ fi
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH="/Users/huantd/.oh-my-zsh"
+export ZSH="$HOME/.oh-my-zsh"
 
 # Set name of the theme to load --- if set to "random", it will
 # load a random theme each time oh-my-zsh is loaded, in which case,
@@ -233,4 +233,4 @@ eval "$(rbenv init - zsh)"
 export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 # Added by Windsurf
-export PATH="/Users/huantd/.codeium/windsurf/bin:$PATH"
+export PATH="$HOME/.codeium/windsurf/bin:$PATH"


### PR DESCRIPTION
## Summary
- use `$HOME` for oh-my-zsh path
- replace hard-coded Windsurf path with `$HOME`
