### PR TITLE
feat: enable kitty auto font sizing

### DIFF
--- a/kitty/auto-font-size.sh
+++ b/kitty/auto-font-size.sh
@@ -5,21 +5,26 @@
 set -euo pipefail
 SOCKET="unix:/tmp/kitty"
 
-# Determine the width of the primary display
+# Default to a comfortable size for the built-in MacBook Retina display
+size=13
+
+# Determine the width of the primary display using xrandr when available
 if command -v xrandr >/dev/null 2>&1; then
     width=$(xrandr | awk '/\*/ {print $1; exit}' | cut -d'x' -f1)
-else
-    width=""
+    if [[ -n "$width" ]]; then
+        if [[ "$width" -ge 3840 ]]; then
+            size=16
+        elif [[ "$width" -ge 1920 ]]; then
+            size=14
+        fi
+    fi
 fi
 
-# Choose a font size based on the detected width
-if [[ -n "$width" ]]; then
-    if [[ "$width" -ge 3840 ]]; then
-        size=16
-    elif [[ "$width" -ge 2560 ]]; then
-        size=14
-    else
-        size=11
+# On macOS, prefer the built-in Retina display font size when detected
+if [[ "$(uname -s)" == "Darwin" ]] && command -v system_profiler >/dev/null 2>&1; then
+    if system_profiler SPDisplaysDataType 2>/dev/null | grep -q "Built-in Retina"; then
+        size=13
     fi
-    kitty @ --to "$SOCKET" set-font-size "$size" >/dev/null 2>&1 || true
 fi
+
+kitty @ --to "$SOCKET" set-font-size "$size" >/dev/null 2>&1 || true

--- a/kitty/auto-font-size.sh
+++ b/kitty/auto-font-size.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Auto-adjust kitty font size based on current screen resolution.
+# Requires kitty to be running with remote control enabled and listening on /tmp/kitty.
+
+set -euo pipefail
+SOCKET="unix:/tmp/kitty"
+
+# Determine the width of the primary display
+if command -v xrandr >/dev/null 2>&1; then
+    width=$(xrandr | awk '/\*/ {print $1; exit}' | cut -d'x' -f1)
+else
+    width=""
+fi
+
+# Choose a font size based on the detected width
+if [[ -n "$width" ]]; then
+    if [[ "$width" -ge 3840 ]]; then
+        size=16
+    elif [[ "$width" -ge 2560 ]]; then
+        size=14
+    else
+        size=11
+    fi
+    kitty @ --to "$SOCKET" set-font-size "$size" >/dev/null 2>&1 || true
+fi

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1089,21 +1089,23 @@ inactive_tab_font_style normal
 #: to yes means that any background processes still using the terminal
 #: can fail silently because their stdout/stderr/stdin no longer work.
 
-# allow_remote_control no
+# Allow other programs to control kitty. If you turn this on other
+# programs can control all aspects of kitty, including sending text
+# to kitty windows, opening new windows, closing windows, reading the
+# content of windows, etc.  Note that this even works over ssh
+# connections. You can chose to either allow any program running
+# within kitty to control it, with yes or only programs that connect
+# to the socket specified with the kitty --listen-on command line
+# option, if you use the value socket-only. The latter is useful if
+# you want to prevent programs running on a remote computer over ssh
+# from controlling kitty. Reloading the config will not affect this
+# setting.
 
-#: Allow other programs to control kitty. If you turn this on other
-#: programs can control all aspects of kitty, including sending text
-#: to kitty windows, opening new windows, closing windows, reading the
-#: content of windows, etc.  Note that this even works over ssh
-#: connections. You can chose to either allow any program running
-#: within kitty to control it, with yes or only programs that connect
-#: to the socket specified with the kitty --listen-on command line
-#: option, if you use the value socket-only. The latter is useful if
-#: you want to prevent programs running on a remote computer over ssh
-#: from controlling kitty. Reloading the config will not affect this
-#: setting.
+# Allow external programs to control kitty, needed for auto font sizing
+allow_remote_control yes
 
-# listen_on none
+# Expose a well known socket so scripts can adjust settings after startup
+listen_on unix:/tmp/kitty
 
 #: Tell kitty to listen to the specified unix/tcp socket for remote
 #: control connections. Note that this will apply to all kitty

--- a/ubuntu/kitty/kitty.conf
+++ b/ubuntu/kitty/kitty.conf
@@ -1089,21 +1089,23 @@ inactive_tab_font_style normal
 #: to yes means that any background processes still using the terminal
 #: can fail silently because their stdout/stderr/stdin no longer work.
 
-# allow_remote_control no
+# Allow other programs to control kitty. If you turn this on other
+# programs can control all aspects of kitty, including sending text
+# to kitty windows, opening new windows, closing windows, reading the
+# content of windows, etc.  Note that this even works over ssh
+# connections. You can chose to either allow any program running
+# within kitty to control it, with yes or only programs that connect
+# to the socket specified with the kitty --listen-on command line
+# option, if you use the value socket-only. The latter is useful if
+# you want to prevent programs running on a remote computer over ssh
+# from controlling kitty. Reloading the config will not affect this
+# setting.
 
-#: Allow other programs to control kitty. If you turn this on other
-#: programs can control all aspects of kitty, including sending text
-#: to kitty windows, opening new windows, closing windows, reading the
-#: content of windows, etc.  Note that this even works over ssh
-#: connections. You can chose to either allow any program running
-#: within kitty to control it, with yes or only programs that connect
-#: to the socket specified with the kitty --listen-on command line
-#: option, if you use the value socket-only. The latter is useful if
-#: you want to prevent programs running on a remote computer over ssh
-#: from controlling kitty. Reloading the config will not affect this
-#: setting.
+# Allow external programs to control kitty, needed for auto font sizing
+allow_remote_control yes
 
-# listen_on none
+# Expose a well known socket so scripts can adjust settings after startup
+listen_on unix:/tmp/kitty
 
 #: Tell kitty to listen to the specified unix/tcp socket for remote
 #: control connections. Note that this will apply to all kitty


### PR DESCRIPTION
## Summary
- allow kitty remote control via fixed socket for automated tweaks
- add script that adjusts font size based on current display width

## Testing
- `bash -n kitty/auto-font-size.sh`
- `./kitty/auto-font-size.sh`
- `shellcheck kitty/auto-font-size.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b163909b10832498d757dcf16651f8