### PR TITLE
lzvim: fix astro LSP typescript.tsdk resolution

### DIFF
--- a/lzvim/lua/plugins/lsp-config.lua
+++ b/lzvim/lua/plugins/lsp-config.lua
@@ -5,6 +5,28 @@ return {
       solargraph = {
         cmd = { os.getenv("HOME") .. "/.rbenv/shims/solargraph", "stdio" },
       },
+      astro = {
+        before_init = function(_, config)
+          local util = require("lspconfig.util")
+          local tsdk = util.get_typescript_server_path(config.root_dir)
+          if tsdk == "" then
+            local npm_root = vim.fn.systemlist("npm root -g")
+            if vim.v.shell_error == 0 and npm_root and npm_root[1] ~= "" then
+              tsdk = npm_root[1] .. "/typescript/lib"
+            end
+          end
+          config.init_options = config.init_options or {}
+          config.init_options.typescript = config.init_options.typescript or {}
+          config.init_options.typescript.tsdk = tsdk
+        end,
+      },
+    },
+    setup = {
+      astro = function(_, opts)
+        vim.lsp.config("astro", opts)
+        vim.lsp.enable("astro")
+        return true
+      end,
     },
   },
 }

--- a/ubuntu/lzvim/lua/plugins/lsp-config.lua
+++ b/ubuntu/lzvim/lua/plugins/lsp-config.lua
@@ -5,6 +5,28 @@ return {
       solargraph = {
         cmd = { os.getenv("HOME") .. "/.rbenv/shims/solargraph", "stdio" },
       },
+      astro = {
+        before_init = function(_, config)
+          local util = require("lspconfig.util")
+          local tsdk = util.get_typescript_server_path(config.root_dir)
+          if tsdk == "" then
+            local npm_root = vim.fn.systemlist("npm root -g")
+            if vim.v.shell_error == 0 and npm_root and npm_root[1] ~= "" then
+              tsdk = npm_root[1] .. "/typescript/lib"
+            end
+          end
+          config.init_options = config.init_options or {}
+          config.init_options.typescript = config.init_options.typescript or {}
+          config.init_options.typescript.tsdk = tsdk
+        end,
+      },
+    },
+    setup = {
+      astro = function(_, opts)
+        vim.lsp.config("astro", opts)
+        vim.lsp.enable("astro")
+        return true
+      end,
     },
   },
 }


### PR DESCRIPTION
## Problem

Opening any `.astro` file failed with:

```
RPC[Error] code_name = InternalError, message = "Request initialize failed with message:
The `typescript.tsdk` init option is required. It should point to a directory containing
a `typescript.js` or `tsserverlibrary.js` file, such as `node_modules/typescript/lib`."
```

Two compounding causes:

1. **mason-lspconfig overwrites user opts.** `automatic_enable.lua:42-44` does
   `vim.lsp.config(name, require("mason-lspconfig.lsp.<name>"))` for every Mason-installed
   server *after* LazyVim applies `opts.servers.astro`. The patch in
   `mason-lspconfig/lsp/astro.lua` unconditionally assigns
   `config.init_options.typescript.tsdk` via its own resolver, replacing any
   user-supplied `before_init`. Traced live:

   ```
   vim.lsp.config('astro', ...) called   # before_init src: lsp-config.lua:9
   vim.lsp.config('astro', ...) called   # before_init src: mason-lspconfig/lsp/astro.lua:2
   ```

2. **TypeScript 7.x dropped the legacy lib layout.** The Mason-vendored
   `typescript` (7.0.2) and the user's global `typescript@7.0.2` both ship only
   `lib/{getExePath,tsc,version}.{js,cjs}` — no `tsserverlibrary.js` or
   `typescript.js`. mason-lspconfig's resolver returns `nil` for both
   workspace-local (when missing) and Mason-vendored TS, leaving `tsdk = nil`
   → server throws.

## Solution

- **Bypass mason-lspconfig for `astro`** via LazyVim's `setup.astro` hook. Calling
  `vim.lsp.config` / `vim.lsp.enable` ourselves and returning `true` excludes
  the server from `automatic_enable`, so the patch is never applied and our
  `before_init` survives.
- **Custom `before_init`** that mirrors the lspconfig resolver but with a global
  fallback:
  1. `lspconfig.util.get_typescript_server_path(root_dir)` — walks up looking for
     `node_modules/typescript/lib` (project-local TS wins).
  2. `npm root -g` + `/typescript/lib` — fallback for projects without local TS.

### User action required

TypeScript 7.x is incompatible with `@astrojs/language-server@2.x`. As long as
the global `typescript` is on 7.x, the fallback path will still fail. Downgrade
once:

```sh
npm install -g typescript@6
```

Projects that ship their own `typescript` (e.g. `emobase-web` at 5.9.3) work
without this step via the workspace-local branch.

## Test plan

- [x] `npm install -g typescript@6` (or any 5.x/6.x with `tsserverlibrary.js`)
- [x] Restart Neovim
- [ ] Open a `.astro` file in a project with local `node_modules/typescript` —
      LSP attaches, completions/diagnostics fire
- [x] Open a `.astro` file in a project without local TS — LSP attaches via the
      global fallback
- [x] `:messages` clear of the `typescript.tsdk` assertion
- [x] `:che vim.lsp` shows `astro` client attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)